### PR TITLE
cmake now produces output identical to configure/make, and CI verifies this.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,26 +1,46 @@
-check_ubu1804_task:
-  container:
-    dockerfile: tooling/cirrus/ubu1804/Dockerfile
-  test_script:
-    - cc --version
-    - mkdir btmp; cd btmp; cmake -G Ninja .. && ninja && ctest -V
-  always:
-    junit_artifacts:
-      path: "btmp/*-results.xml"
-      type: text/xml
-      format: junit
+upload_junit_template: &UPLOAD_JUNIT
+   always:
+     junit_artifacts:
+       path: "btmp/*-results.xml"
+       type: text/xml
+       format: junit
 
-check_ubu2004_task:
-  container:
-    dockerfile: tooling/cirrus/ubu2004/Dockerfile
+check_docker_task:
+  matrix:
+    - name: "ubu1404"
+      container:
+        dockerfile: tooling/cirrus/ubu1404/Dockerfile   # remove 2022/4
+    - name: "ubu1604"
+      container:
+        dockerfile: tooling/cirrus/ubu1604/Dockerfile   # remove 2024/4
+    - name: "ubu1804"
+      container:
+        dockerfile: tooling/cirrus/ubu1804/Dockerfile   # remove 2028/4
+    - name: "ubu2004"
+      container:
+        dockerfile: tooling/cirrus/ubu2004/Dockerfile
+    - name: "ubu2010"
+      container:
+        dockerfile: tooling/cirrus/ubu2010/Dockerfile   # remove 2021/7
+    - name: "debian8"
+      container:
+        dockerfile: tooling/cirrus/debian8/Dockerfile   # remove 2020/7
+    - name: "debian9"
+      container:
+        dockerfile: tooling/cirrus/debian9/Dockerfile   # remove 2022/7
+    - name: "debian10"
+      container:
+        dockerfile: tooling/cirrus/debian10/Dockerfile
+    - name: "fedora31"
+      container:
+        dockerfile: tooling/cirrus/fedora31/Dockerfile  # remove 2020/11
+    - name: "fedora32"
+      container:
+        dockerfile: tooling/cirrus/fedora32/Dockerfile  # remove 2021/5
   test_script:
-    - cc --version
-    - mkdir btmp; cd btmp; cmake -G Ninja .. && ninja && ctest -V
-  always:
-    junit_artifacts:
-      path: "btmp/*-results.xml"
-      type: text/xml
-      format: junit
+    - cat /etc/issue || true; cat /etc/os-release || true; uname -a || true
+    - sh tooling/test-cmake.sh && sh tooling/pkgcheck.sh
+  << : *UPLOAD_JUNIT
 
 check_mac_task:
   osx_instance:
@@ -28,14 +48,8 @@ check_mac_task:
   install_script:
     - brew install ninja
   test_script:
-    - cc --version
-    - ninja --version
-    - mkdir btmp; cd btmp; cmake -G Ninja .. && cmake --build . && ctest -V
-  always:
-    junit_artifacts:
-      path: "btmp/*-results.xml"
-      type: text/xml
-      format: junit
+    - sh tooling/test-cmake.sh && sh tooling/pkgcheck.sh
+  << : *UPLOAD_JUNIT
 
 check_bsd_task:
   freebsd_instance:
@@ -43,13 +57,8 @@ check_bsd_task:
   install_script:
     - pkg install -y gcc cmake ninja
   test_script:
-    - cc --version
-    - mkdir btmp; cd btmp; cmake -G Ninja .. && ninja && ctest -V
-  always:
-    junit_artifacts:
-      path: "btmp/*-results.xml"
-      type: text/xml
-      format: junit
+    - sh tooling/test-cmake.sh && sh tooling/pkgcheck.sh
+  << : *UPLOAD_JUNIT
 
 check_win_task:
   windows_container:
@@ -61,8 +70,4 @@ check_win_task:
     - ninja --version
     - echo "Setting compiler to MSVC rather than the default (GCC from chocolatey)"
     - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat" && where cl && set CC=cl && mkdir btmp && cd btmp && cmake -G Ninja .. && ninja && ctest -V
-  always:
-    junit_artifacts:
-      path: "btmp/*-results.xml"
-      type: text/xml
-      format: junit
+  << : *UPLOAD_JUNIT

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,68 @@
+check_ubu1804_task:
+  container:
+    dockerfile: tooling/cirrus/ubu1804/Dockerfile
+  test_script:
+    - cc --version
+    - mkdir btmp; cd btmp; cmake -G Ninja .. && ninja && ctest -V
+  always:
+    junit_artifacts:
+      path: "btmp/*-results.xml"
+      type: text/xml
+      format: junit
+
+check_ubu2004_task:
+  container:
+    dockerfile: tooling/cirrus/ubu2004/Dockerfile
+  test_script:
+    - cc --version
+    - mkdir btmp; cd btmp; cmake -G Ninja .. && ninja && ctest -V
+  always:
+    junit_artifacts:
+      path: "btmp/*-results.xml"
+      type: text/xml
+      format: junit
+
+check_mac_task:
+  osx_instance:
+    image: catalina-xcode
+  install_script:
+    - brew install ninja
+  test_script:
+    - cc --version
+    - ninja --version
+    - mkdir btmp; cd btmp; cmake -G Ninja .. && cmake --build . && ctest -V
+  always:
+    junit_artifacts:
+      path: "btmp/*-results.xml"
+      type: text/xml
+      format: junit
+
+check_bsd_task:
+  freebsd_instance:
+    image_family: freebsd-12-1
+  install_script:
+    - pkg install -y gcc cmake ninja
+  test_script:
+    - cc --version
+    - mkdir btmp; cd btmp; cmake -G Ninja .. && ninja && ctest -V
+  always:
+    junit_artifacts:
+      path: "btmp/*-results.xml"
+      type: text/xml
+      format: junit
+
+check_win_task:
+  windows_container:
+    image: cirrusci/windowsservercore:cmake
+  install_script:
+    - choco install -y --no-progress ninja
+  test_script:
+    - cmake --version
+    - ninja --version
+    - echo "Setting compiler to MSVC rather than the default (GCC from chocolatey)"
+    - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat" && where cl && set CC=cl && mkdir btmp && cd btmp && cmake -G Ninja .. && ninja && ctest -V
+  always:
+    junit_artifacts:
+      path: "btmp/*-results.xml"
+      type: text/xml
+      format: junit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@ set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS ON)
 
 project(zlib C)
 
+# parse the full version number from zlib.h and include in ZLIB_FULL_VERSION
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/zlib.h _zlib_h_contents)
+string(REGEX REPLACE ".*#define[ \t]+ZLIB_VERSION[ \t]+\"([-0-9A-Za-z.]+)\".*"
+    "\\1" ZLIB_FULL_VERSION ${_zlib_h_contents})
+# FIXME: parse VERSION from ZLIB_FULL_VERSION
 set(VERSION "1.2.11.1")
 
 option(ASM686 "Enable building i686 assembly implementation")
@@ -12,7 +17,16 @@ set(INSTALL_BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Installation direc
 set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Installation directory for libraries")
 set(INSTALL_INC_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "Installation directory for headers")
 set(INSTALL_MAN_DIR "${CMAKE_INSTALL_PREFIX}/share/man" CACHE PATH "Installation directory for manual pages")
-set(INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_PREFIX}/share/pkgconfig" CACHE PATH "Installation directory for pkgconfig (.pc) files")
+set(INSTALL_PKGCONFIG_DIR "${INSTALL_LIB_DIR}/pkgconfig" CACHE PATH "Installation directory for pkgconfig (.pc) files")
+
+# Set a default build type if none was specified
+set(default_build_type "Release")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
 
 include(CheckTypeSize)
 include(CheckFunctionExists)
@@ -21,8 +35,35 @@ include(CheckCSourceCompiles)
 enable_testing()
 
 check_include_file(sys/types.h HAVE_SYS_TYPES_H)
+check_include_file(stdarg.h    HAVE_STDARG_H)
 check_include_file(stdint.h    HAVE_STDINT_H)
 check_include_file(stddef.h    HAVE_STDDEF_H)
+check_include_file(unistd.h    HAVE_UNISTD_H)
+
+#
+# Match configure's zconf.h exactly
+#
+if (HAVE_STDARG_H)
+  SET(ZCONF_STDARG_LINE "#if 1    /* was set to #if 1 by ./configure */")
+else()
+  SET(ZCONF_STDARG_LINE "#ifdef HAVE_STDARG_H    /* may be set to #if 1 by ./configure */")
+endif()
+if (HAVE_UNISTD_H)
+  SET(ZCONF_UNISTD_LINE "#if 1    /* was set to #if 1 by ./configure */")
+else()
+  SET(ZCONF_UNISTD_LINE "#ifdef HAVE_UNISTD_H    /* may be set to #if 1 by ./configure */")
+endif()
+
+#
+# Check to see if compiler supports __attribute__((visibility ("hidden")))
+#
+check_c_source_compiles(
+    "int __attribute__((visibility (\"hidden\"))) foo; int main() { return foo; }"
+    HAVE_HIDDEN
+)
+if(HAVE_HIDDEN)
+    add_definitions(-DHAVE_HIDDEN)
+endif()
 
 #
 # Check to see if we have large file support
@@ -57,7 +98,7 @@ endif()
 #
 # Check for unistd.h
 #
-check_include_file(unistd.h Z_HAVE_UNISTD_H)
+check_include_file(unistd.h HAVE_UNISTD_H)
 
 if(MSVC)
     set(CMAKE_DEBUG_POSTFIX "d")
@@ -76,6 +117,19 @@ if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
         message(STATUS "but CMake generates it automatically in the build directory.")
         file(RENAME ${CMAKE_CURRENT_SOURCE_DIR}/zconf.h ${CMAKE_CURRENT_SOURCE_DIR}/zconf.h.included)
   endif()
+endif()
+
+# Refer to prefix symbolically to ease relocation by end user,
+# and match Makefile-generate .pc file exactly.
+if(INSTALL_INC_DIR STREQUAL "${CMAKE_INSTALL_PREFIX}/include")
+  set(PC_INSTALL_INC_DIR "\${prefix}/include")
+else()
+  set(PC_INSTALL_INC_DIR "${INSTALL_INC_DIR}")
+endif()
+if(INSTALL_LIB_DIR STREQUAL "${CMAKE_INSTALL_PREFIX}/lib")
+  set(PC_INSTALL_LIB_DIR "\${exec_prefix}/lib")
+else()
+  set(PC_INSTALL_LIB_DIR "${INSTALL_LIB_DIR}")
 endif()
 
 set(ZLIB_PC ${CMAKE_CURRENT_BINARY_DIR}/zlib.pc)
@@ -105,22 +159,27 @@ set(ZLIB_PRIVATE_HDRS
     trees.h
     zutil.h
 )
+
+# Note: keep these in the same order as in Makefile.in
+# This allows libz.so to be identical between the two build systems.
 set(ZLIB_SRCS
+    # Makefile.in: PIC_OBJZ
     adler32.c
-    compress.c
     crc32.c
     deflate.c
+    infback.c
+    inffast.c
+    inflate.c
+    inftrees.c
+    trees.c
+    zutil.c
+    # Makefile.in: PIC_OBJG
+    compress.c
+    uncompr.c
     gzclose.c
     gzlib.c
     gzread.c
     gzwrite.c
-    inflate.c
-    infback.c
-    inftrees.c
-    inffast.c
-    trees.c
-    uncompr.c
-    zutil.c
 )
 
 if(NOT MINGW)
@@ -162,11 +221,6 @@ if(MSVC)
 	endif()
 endif()
 
-# parse the full version number from zlib.h and include in ZLIB_FULL_VERSION
-file(READ ${CMAKE_CURRENT_SOURCE_DIR}/zlib.h _zlib_h_contents)
-string(REGEX REPLACE ".*#define[ \t]+ZLIB_VERSION[ \t]+\"([-0-9A-Za-z.]+)\".*"
-    "\\1" ZLIB_FULL_VERSION ${_zlib_h_contents})
-
 if(MINGW)
     # This gets us DLL resource information when compiling on MinGW.
     if(NOT CMAKE_RC_COMPILER)
@@ -204,6 +258,9 @@ if(UNIX)
    set_target_properties(zlib zlibstatic PROPERTIES OUTPUT_NAME z)
    if(NOT APPLE)
      set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/zlib.map\"")
+     # Makefile.in uses -lc...
+     set(LDSHAREDLIBC -lc)
+     target_link_libraries(zlib ${LDSHAREDLIBC})
    endif()
 elseif(BUILD_SHARED_LIBS AND WIN32)
     # Creates zlib1.dll when building shared library version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,7 +232,8 @@ endif()
 
 add_executable(example test/example.c)
 target_link_libraries(example zlib)
-add_test(example example)
+# Note: would like to put it in $<CONFIG> subdir, but generator expressions are not expanded as one would expect?
+add_test(example example --junit "${CMAKE_CURRENT_BINARY_DIR}/example-results.xml")
 
 add_executable(minigzip test/minigzip.c)
 target_link_libraries(minigzip zlib)
@@ -241,7 +242,7 @@ if(HAVE_OFF64_T)
     add_executable(example64 test/example.c)
     target_link_libraries(example64 zlib)
     set_target_properties(example64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
-    add_test(example64 example64)
+    add_test(example64 example64 --junit "${CMAKE_CURRENT_BINARY_DIR}/example64-results.xml")
 
     add_executable(minigzip64 test/minigzip.c)
     target_link_libraries(minigzip64 zlib)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ZLIB DATA COMPRESSION LIBRARY
 
-[![AppVeyor CI status][appveyor-shield]][appveyor-link]
+[![AppVeyor CI status][appveyor-shield]][appveyor-link][![Cirrus CI status][cirrus-shield]][cirrus-link]
 
 zlib 1.2.11.1 is a general purpose data compression library.  All the code is
 thread safe.  The data format used by the zlib library is described by RFCs
@@ -118,5 +118,8 @@ If you redistribute modified sources, we would appreciate that you include in
 the file ChangeLog history information documenting your changes.  Please read
 the FAQ for more information on the distribution of modified source versions.
 
-[appveyor-shield]: https://ci.appveyor.com/api/projects/status/8m7p0nbuy8tvkqv6/branch/add-appveyor?svg=true
-[appveyor-link]: https://ci.appveyor.com/project/ProgramMax/zlib/branch/develop
+<!-- fix following four lines when merging -->
+[appveyor-shield]: https://ci.appveyor.com/api/projects/status/h80iqyhbe09p29n0/branch/develop?svg=true
+[appveyor-link]: https://ci.appveyor.com/project/dankegel/zlib/branch/develop
+[cirrus-shield]: https://api.cirrus-ci.com/github/dankegel/zlib.svg?branch=develop
+[cirrus-link]: https://cirrus-ci.com/github/dankegel/zlib/develop

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ZLIB DATA COMPRESSION LIBRARY
 
+[![AppVeyor CI status][appveyor-shield]][appveyor-link]
+
 zlib 1.2.11.1 is a general purpose data compression library.  All the code is
 thread safe.  The data format used by the zlib library is described by RFCs
 (Request for Comments) 1950 to 1952 in the files
@@ -102,8 +104,7 @@ Copyright notice:
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 
-  Jean-loup Gailly        Mark Adler
-  jloup@gzip.org          madler@alumni.caltech.edu
+  Jean-loup Gailly (jloup@gzip.org) & Mark Adler (madler@alumni.caltech.edu)
 
 If you use the zlib library in a product, we would appreciate *not* receiving
 lengthy legal documents to sign.  The sources are provided for free but without
@@ -116,3 +117,6 @@ any third parties.
 If you redistribute modified sources, we would appreciate that you include in
 the file ChangeLog history information documenting your changes.  Please read
 the FAQ for more information on the distribution of modified source versions.
+
+[appveyor-shield]: https://ci.appveyor.com/api/projects/status/8m7p0nbuy8tvkqv6/branch/add-appveyor?svg=true
+[appveyor-link]: https://ci.appveyor.com/project/ProgramMax/zlib/branch/develop

--- a/configure
+++ b/configure
@@ -25,7 +25,7 @@ if test $SRCDIR = "."; then
     ZINCOUT="-I."
     SRCDIR=""
 else
-    ZINC='-include zconf.h'
+    ZINC='-I. -include zconf.h'
     ZINCOUT='-I. -I$(SRCDIR)'
     SRCDIR="$SRCDIR/"
 fi

--- a/test/example.c
+++ b/test/example.c
@@ -654,7 +654,7 @@ test_result test_dict_inflate(compr, comprLen, uncompr, uncomprLen)
 }
 
 /* ===========================================================================
- * Usage:  example [--junit results.xml] [output.gz  [input.gz]]
+ * Usage:  example [--junit results.xml] [output.gz]
  */
 
 int main(argc, argv)
@@ -717,10 +717,7 @@ int main(argc, argv)
         fprintf(g_junit_output, "\t<testsuite name=\"zlib example suite\">\n");
     }
 
-#ifdef Z_SOLO
-    (void)argc;
-    (void)argv;
-#else
+#ifndef Z_SOLO
     result = test_compress(compr, comprLen, uncompr, uncomprLen);
     handle_test_results(result, "compress");
 	

--- a/test/example.c
+++ b/test/example.c
@@ -151,6 +151,7 @@ test_result test_dict_deflate  OF((Byte *compr, uLong comprLen));
 test_result test_dict_inflate  OF((Byte *compr, uLong comprLen,
                                    Byte *uncompr, uLong uncomprLen));
 test_result test_self          OF((void));
+test_result test_self_verbose  OF((void));
 int  main                      OF((int argc, char *argv[]));
 
 
@@ -667,8 +668,19 @@ test_result test_self()
     if (g_force_fail)
         err = 54321;
     CHECK_ERR(err, "forced");
-
     RETURN_SUCCESS(NULL, NULL);
+}
+
+/* ===========================================================================
+ * Optionally test fault injection.
+ */
+test_result test_self_verbose()
+{
+    if (g_force_fail) {
+        RETURN_FAILURE("forced: ", "by --force_failure");
+    } else {
+        RETURN_SUCCESS(NULL, NULL);
+    }
 }
 
 /* ===========================================================================
@@ -745,6 +757,8 @@ int main(argc, argv)
 
     result = test_self();
     handle_test_results(result, "self");
+    result = test_self_verbose();
+    handle_test_results(result, "self verbose");
 
 #ifndef Z_SOLO
     result = test_compress(compr, comprLen, uncompr, uncomprLen);

--- a/test/example.c
+++ b/test/example.c
@@ -27,6 +27,7 @@ const char *g_junit_ofname;
 FILE *g_junit_output;
 int g_fail_fast;
 int g_failed_test_count;
+int g_force_fail;
 
 typedef struct test_result_s {
     int         result; /* One of: SUCCESSFUL,
@@ -149,6 +150,7 @@ test_result test_sync          OF((Byte *compr, uLong comprLen,
 test_result test_dict_deflate  OF((Byte *compr, uLong comprLen));
 test_result test_dict_inflate  OF((Byte *compr, uLong comprLen,
                                    Byte *uncompr, uLong uncomprLen));
+test_result test_self          OF((void));
 int  main                      OF((int argc, char *argv[]));
 
 
@@ -657,7 +659,20 @@ test_result test_dict_inflate(compr, comprLen, uncompr, uncomprLen)
 }
 
 /* ===========================================================================
- * Usage:  example [--fail_fast][--junit results.xml] [output.gz]
+ * Optionally test fault injection.
+ */
+test_result test_self()
+{
+    int err = Z_OK;
+    if (g_force_fail)
+        err = 54321;
+    CHECK_ERR(err, "forced");
+
+    RETURN_SUCCESS(NULL, NULL);
+}
+
+/* ===========================================================================
+ * Usage:  example [--fail_fast][--force_fail][--junit results.xml] [output.gz]
  */
 
 int main(argc, argv)
@@ -696,6 +711,7 @@ int main(argc, argv)
      */
     g_junit_ofname = getenv("ZLIBTEST_JUNIT");
     g_fail_fast = getenv("ZLIBTEST_FAIL_FAST") && atoi(getenv("ZLIBTEST_FAIL_FAST"));
+    g_force_fail = getenv("ZLIBTEST_FORCE_FAIL") && atoi(getenv("ZLIBTEST_FORCE_FAIL"));
     while (next_argv_index < argc && !strncmp(argv[next_argv_index], "--", 2)) {
         if (strcmp(argv[next_argv_index], "--junit") == 0) {
             next_argv_index++;
@@ -707,6 +723,9 @@ int main(argc, argv)
             next_argv_index++;
         } else if (strcmp(argv[next_argv_index], "--fail_fast") == 0) {
             g_fail_fast = 1;
+            next_argv_index++;
+        } else if (strcmp(argv[next_argv_index], "--force_fail") == 0) {
+            g_force_fail = 1;
             next_argv_index++;
         } else {
             fprintf(stderr, "Unrecognized option %s\n", argv[next_argv_index]);
@@ -723,6 +742,9 @@ int main(argc, argv)
         fprintf(g_junit_output, "<testsuites>\n");
         fprintf(g_junit_output, "\t<testsuite name=\"zlib example suite\">\n");
     }
+
+    result = test_self();
+    handle_test_results(result, "self");
 
 #ifndef Z_SOLO
     result = test_compress(compr, comprLen, uncompr, uncomprLen);

--- a/test/example.c
+++ b/test/example.c
@@ -37,15 +37,13 @@ typedef struct test_result_s {
 char string_buffer[STRING_BUFFER_SIZE];
 
 #define RETURN_ON_ERROR_WITH_MESSAGE(_error_code, _message) { \
-    { \
+    if (_error_code != Z_OK) { \
         test_result result; \
-        if (_error_code != Z_OK) { \
-            result.result = FAILED_WITH_ERROR_CODE; \
-            result.error_code = _error_code; \
-            result.line_number = __LINE__; \
-            result.message = _message; \
-            return result; \
-        } \
+        result.result = FAILED_WITH_ERROR_CODE; \
+        result.error_code = _error_code; \
+        result.line_number = __LINE__; \
+        result.message = _message; \
+        return result; \
     } \
 }
 

--- a/test/example.c
+++ b/test/example.c
@@ -19,11 +19,92 @@
 #  define TESTFILE "foo.gz"
 #endif
 
-#define CHECK_ERR(err, msg) { \
-    if (err != Z_OK) { \
-        fprintf(stderr, "%s error: %d\n", msg, err); \
-        exit(1); \
+#define SUCCESSFUL                 1
+#define FAILED_WITH_ERROR_CODE     0
+#define FAILED_WITHOUT_ERROR_CODE -1
+
+typedef struct test_result_s {
+    int           result; /* One of: SUCCESSFUL,
+                          FAILED_WITH_ERROR_CODE, or
+                          FAILED_WITHOUT_ERROR_CODE*/
+    int           error_code; /* error code if success is FAILED_WITH_ERROR_CODE */
+    int           line_number;
+    z_const char* message;
+    z_const char* extended_message;
+} test_result;
+
+#define STRING_BUFFER_SIZE 100
+char string_buffer[STRING_BUFFER_SIZE];
+
+#define RETURN_ON_ERROR_WITH_MESSAGE(_error_code, _message, _result) { \
+    if (_error_code != Z_OK) { \
+        _result.result = FAILED_WITH_ERROR_CODE; \
+        _result.error_code = _error_code; \
+        _result.line_number = __LINE__; \
+        _result.message = _message; \
+        return _result; \
     } \
+}
+
+#define RETURN_WITH_MESSAGE(_message, _result) { \
+    _result.result = FAILED_WITHOUT_ERROR_CODE; \
+    _result.line_number = __LINE__; \
+    _result.message = _message; \
+    return result; \
+}
+
+#define RETURN_WITH_EXTENDED_MESSAGE(_message, _extended_message, _result) { \
+    _result.result = FAILED_WITHOUT_ERROR_CODE; \
+    _result.line_number = __LINE__; \
+    _result.message = _message; \
+    _result.extended_message = _extended_message; \
+    return result; \
+}
+
+void handle_test_results(FILE* output, test_result result, z_const char* testcase_name, int is_junit_output, int* failed_test_count) {
+    if (is_junit_output) {
+        fprintf(output, "\t\t<testcase name=\"%s\">", testcase_name);
+    }
+
+    if (result.result == FAILED_WITH_ERROR_CODE) {
+        (*failed_test_count)++;
+        if (is_junit_output) {
+            fprintf(output, "\n\t\t\t<failure file=\"%s\" line=\"%d\">%s error: %d</failure>\n\t\t", __FILE__, result.line_number, result.message, result.error_code);
+        } else {
+            fprintf(stderr, "%s error: %d\n", result.message, result.error_code);
+            exit(1);
+        }
+    } else if (result.result == FAILED_WITHOUT_ERROR_CODE) {
+        (*failed_test_count)++;
+        if (is_junit_output) {
+            fprintf(output, "\n\t\t\t<failure file=\"%s\" line=\"%d\">%s", __FILE__, result.line_number, result.message);
+            if (result.extended_message != NULL) {
+                fprintf(output, "%s", result.extended_message);
+            }
+            fprintf(output, "</failure>\n\t\t");
+        } else {
+            fprintf(stderr, "%s", result.message);
+            if (result.extended_message != NULL) {
+                fprintf(stderr, "%s", result.extended_message);
+            }
+            fprintf(stderr, "\n");
+            exit(1);
+        }
+    } else {
+        if (!is_junit_output) {
+            if (result.message != NULL) {
+                if (result.extended_message != NULL) {
+                    fprintf(output, "%s%s\n", result.message, result.extended_message);
+                } else {
+                    fprintf(stderr, "%s", result.message);
+                }
+            }
+        }
+    }
+
+    if (is_junit_output) {
+        fprintf(output, "</testcase>\n");
+    }
 }
 
 static z_const char hello[] = "hello, hello!";
@@ -34,20 +115,20 @@ static z_const char hello[] = "hello, hello!";
 static const char dictionary[] = "hello";
 static uLong dictId;    /* Adler32 value of the dictionary */
 
-void test_deflate       OF((Byte *compr, uLong comprLen));
-void test_inflate       OF((Byte *compr, uLong comprLen,
-                            Byte *uncompr, uLong uncomprLen));
-void test_large_deflate OF((Byte *compr, uLong comprLen,
-                            Byte *uncompr, uLong uncomprLen));
-void test_large_inflate OF((Byte *compr, uLong comprLen,
-                            Byte *uncompr, uLong uncomprLen));
-void test_flush         OF((Byte *compr, uLong *comprLen));
-void test_sync          OF((Byte *compr, uLong comprLen,
-                            Byte *uncompr, uLong uncomprLen));
-void test_dict_deflate  OF((Byte *compr, uLong comprLen));
-void test_dict_inflate  OF((Byte *compr, uLong comprLen,
-                            Byte *uncompr, uLong uncomprLen));
-int  main               OF((int argc, char *argv[]));
+test_result test_deflate       OF((Byte *compr, uLong comprLen));
+test_result test_inflate       OF((Byte *compr, uLong comprLen,
+                                   Byte *uncompr, uLong uncomprLen));
+test_result test_large_deflate OF((Byte *compr, uLong comprLen,
+                                   Byte *uncompr, uLong uncomprLen));
+test_result test_large_inflate OF((Byte *compr, uLong comprLen,
+                                   Byte *uncompr, uLong uncomprLen));
+test_result test_flush         OF((Byte *compr, uLong *comprLen));
+test_result test_sync          OF((Byte *compr, uLong comprLen,
+                                   Byte *uncompr, uLong uncomprLen));
+test_result test_dict_deflate  OF((Byte *compr, uLong comprLen));
+test_result test_dict_inflate  OF((Byte *compr, uLong comprLen,
+                                   Byte *uncompr, uLong uncomprLen));
+int  main                      OF((int argc, char *argv[]));
 
 
 #ifdef Z_SOLO
@@ -77,118 +158,122 @@ static free_func zfree = myfree;
 static alloc_func zalloc = (alloc_func)0;
 static free_func zfree = (free_func)0;
 
-void test_compress      OF((Byte *compr, uLong comprLen,
-                            Byte *uncompr, uLong uncomprLen));
-void test_gzio          OF((const char *fname,
-                            Byte *uncompr, uLong uncomprLen));
+test_result test_compress      OF((Byte *compr, uLong comprLen,
+                                   Byte *uncompr, uLong uncomprLen));
+test_result test_gzio          OF((const char *fname,
+                                   Byte *uncompr, uLong uncomprLen));
 
 /* ===========================================================================
  * Test compress() and uncompress()
  */
-void test_compress(compr, comprLen, uncompr, uncomprLen)
+test_result test_compress(compr, comprLen, uncompr, uncomprLen)
     Byte *compr, *uncompr;
     uLong comprLen, uncomprLen;
 {
     int err;
     uLong len = (uLong)strlen(hello)+1;
+    test_result result;
 
     err = compress(compr, &comprLen, (const Bytef*)hello, len);
-    CHECK_ERR(err, "compress");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "compress", result);
 
     strcpy((char*)uncompr, "garbage");
 
     err = uncompress(uncompr, &uncomprLen, compr, comprLen);
-    CHECK_ERR(err, "uncompress");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "uncompress", result);
 
     if (strcmp((char*)uncompr, hello)) {
-        fprintf(stderr, "bad uncompress\n");
-        exit(1);
+        RETURN_WITH_MESSAGE("bad uncompress\n", result);
     } else {
-        printf("uncompress(): %s\n", (char *)uncompr);
+        result.result = SUCCESSFUL;
+        result.message = "uncompress(): ";
+        result.extended_message = (char*)uncompr;
+        return result;
     }
 }
 
 /* ===========================================================================
  * Test read/write of .gz files
  */
-void test_gzio(fname, uncompr, uncomprLen)
+test_result test_gzio(fname, uncompr, uncomprLen)
     const char *fname; /* compressed file name */
     Byte *uncompr;
     uLong uncomprLen;
 {
 #ifdef NO_GZCOMPRESS
-    fprintf(stderr, "NO_GZCOMPRESS -- gz* functions cannot compress\n");
+    test_result result;
+    result.success = FAILED_WITHOUT_ERROR_CODE;
+    result.message = "NO_GZCOMPRESS -- gz* functions cannot compress";
+    return result;
 #else
     int err;
     int len = (int)strlen(hello)+1;
     gzFile file;
     z_off_t pos;
+    test_result result;
 
     file = gzopen(fname, "wb");
     if (file == NULL) {
-        fprintf(stderr, "gzopen error\n");
-        exit(1);
+        RETURN_WITH_MESSAGE("gzopen error", result);
     }
     gzputc(file, 'h');
     if (gzputs(file, "ello") != 4) {
-        fprintf(stderr, "gzputs err: %s\n", gzerror(file, &err));
-        exit(1);
+        RETURN_WITH_EXTENDED_MESSAGE("gzputs err: ", gzerror(file, &err), result);
     }
     if (gzprintf(file, ", %s!", "hello") != 8) {
-        fprintf(stderr, "gzprintf err: %s\n", gzerror(file, &err));
-        exit(1);
+        RETURN_WITH_EXTENDED_MESSAGE("gzprintf err: ", gzerror(file, &err), result);
     }
     gzseek(file, 1L, SEEK_CUR); /* add one zero byte */
     gzclose(file);
 
     file = gzopen(fname, "rb");
     if (file == NULL) {
-        fprintf(stderr, "gzopen error\n");
-        exit(1);
+        RETURN_WITH_MESSAGE("gzopen error", result);
     }
     strcpy((char*)uncompr, "garbage");
 
     if (gzread(file, uncompr, (unsigned)uncomprLen) != len) {
-        fprintf(stderr, "gzread err: %s\n", gzerror(file, &err));
-        exit(1);
+        RETURN_WITH_EXTENDED_MESSAGE("gzread err: ", gzerror(file, &err), result);
     }
     if (strcmp((char*)uncompr, hello)) {
-        fprintf(stderr, "bad gzread: %s\n", (char*)uncompr);
-        exit(1);
+        RETURN_WITH_EXTENDED_MESSAGE("bad gzread: ", (char*)uncompr, result);
     } else {
         printf("gzread(): %s\n", (char*)uncompr);
     }
 
     pos = gzseek(file, -8L, SEEK_CUR);
     if (pos != 6 || gztell(file) != pos) {
-        fprintf(stderr, "gzseek error, pos=%ld, gztell=%ld\n",
+        sprintf(string_buffer, "gzseek error, pos=%ld, gztell=%ld\n",
                 (long)pos, (long)gztell(file));
-        exit(1);
+        result.result = FAILED_WITHOUT_ERROR_CODE;
+        result.line_number = __LINE__;
+        result.message = string_buffer;
+        return result;
     }
 
     if (gzgetc(file) != ' ') {
-        fprintf(stderr, "gzgetc error\n");
-        exit(1);
+        RETURN_WITH_MESSAGE("gzgetc error", result);
     }
 
     if (gzungetc(' ', file) != ' ') {
-        fprintf(stderr, "gzungetc error\n");
-        exit(1);
+        RETURN_WITH_MESSAGE("gzungetc error", result);
     }
 
     gzgets(file, (char*)uncompr, (int)uncomprLen);
     if (strlen((char*)uncompr) != 7) { /* " hello!" */
-        fprintf(stderr, "gzgets err after gzseek: %s\n", gzerror(file, &err));
-        exit(1);
+        RETURN_WITH_EXTENDED_MESSAGE("gzgets err after gzseek: ", gzerror(file, &err), result);
     }
     if (strcmp((char*)uncompr, hello + 6)) {
-        fprintf(stderr, "bad gzgets after gzseek\n");
-        exit(1);
+        RETURN_WITH_MESSAGE("bad gzgets after gzseek", result);
     } else {
         printf("gzgets() after gzseek: %s\n", (char*)uncompr);
     }
 
     gzclose(file);
+
+    result.result = SUCCESSFUL;
+    result.message = NULL;
+    return result;
 #endif
 }
 
@@ -197,20 +282,21 @@ void test_gzio(fname, uncompr, uncomprLen)
 /* ===========================================================================
  * Test deflate() with small buffers
  */
-void test_deflate(compr, comprLen)
+test_result test_deflate(compr, comprLen)
     Byte *compr;
     uLong comprLen;
 {
     z_stream c_stream; /* compression stream */
     int err;
     uLong len = (uLong)strlen(hello)+1;
+    test_result result;
 
     c_stream.zalloc = zalloc;
     c_stream.zfree = zfree;
     c_stream.opaque = (voidpf)0;
 
     err = deflateInit(&c_stream, Z_DEFAULT_COMPRESSION);
-    CHECK_ERR(err, "deflateInit");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "deflateInit", result);
 
     c_stream.next_in  = (z_const unsigned char *)hello;
     c_stream.next_out = compr;
@@ -218,29 +304,34 @@ void test_deflate(compr, comprLen)
     while (c_stream.total_in != len && c_stream.total_out < comprLen) {
         c_stream.avail_in = c_stream.avail_out = 1; /* force small buffers */
         err = deflate(&c_stream, Z_NO_FLUSH);
-        CHECK_ERR(err, "deflate");
+        RETURN_ON_ERROR_WITH_MESSAGE(err, "deflate", result);
     }
     /* Finish the stream, still forcing small buffers: */
     for (;;) {
         c_stream.avail_out = 1;
         err = deflate(&c_stream, Z_FINISH);
         if (err == Z_STREAM_END) break;
-        CHECK_ERR(err, "deflate");
+        RETURN_ON_ERROR_WITH_MESSAGE(err, "deflate", result);
     }
 
     err = deflateEnd(&c_stream);
-    CHECK_ERR(err, "deflateEnd");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "deflateEnd", result);
+
+    result.result = SUCCESSFUL;
+    result.message = NULL;
+    return result;
 }
 
 /* ===========================================================================
  * Test inflate() with small buffers
  */
-void test_inflate(compr, comprLen, uncompr, uncomprLen)
+test_result test_inflate(compr, comprLen, uncompr, uncomprLen)
     Byte *compr, *uncompr;
     uLong comprLen, uncomprLen;
 {
     int err;
     z_stream d_stream; /* decompression stream */
+    test_result result;
 
     strcpy((char*)uncompr, "garbage");
 
@@ -253,42 +344,45 @@ void test_inflate(compr, comprLen, uncompr, uncomprLen)
     d_stream.next_out = uncompr;
 
     err = inflateInit(&d_stream);
-    CHECK_ERR(err, "inflateInit");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "inflateInit", result);
 
     while (d_stream.total_out < uncomprLen && d_stream.total_in < comprLen) {
         d_stream.avail_in = d_stream.avail_out = 1; /* force small buffers */
         err = inflate(&d_stream, Z_NO_FLUSH);
         if (err == Z_STREAM_END) break;
-        CHECK_ERR(err, "inflate");
+        RETURN_ON_ERROR_WITH_MESSAGE(err, "inflate", result);
     }
 
     err = inflateEnd(&d_stream);
-    CHECK_ERR(err, "inflateEnd");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "inflateEnd", result);
 
     if (strcmp((char*)uncompr, hello)) {
-        fprintf(stderr, "bad inflate\n");
-        exit(1);
+        RETURN_WITH_MESSAGE("bad inflate\n", result);
     } else {
-        printf("inflate(): %s\n", (char *)uncompr);
+        result.result = SUCCESSFUL;
+        result.message = "inflate(): ";
+        result.extended_message = (char*)uncompr;
+        return result;
     }
 }
 
 /* ===========================================================================
  * Test deflate() with large buffers and dynamic change of compression level
  */
-void test_large_deflate(compr, comprLen, uncompr, uncomprLen)
+test_result test_large_deflate(compr, comprLen, uncompr, uncomprLen)
     Byte *compr, *uncompr;
     uLong comprLen, uncomprLen;
 {
     z_stream c_stream; /* compression stream */
     int err;
+    test_result result;
 
     c_stream.zalloc = zalloc;
     c_stream.zfree = zfree;
     c_stream.opaque = (voidpf)0;
 
     err = deflateInit(&c_stream, Z_BEST_SPEED);
-    CHECK_ERR(err, "deflateInit");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "deflateInit", result);
 
     c_stream.next_out = compr;
     c_stream.avail_out = (uInt)comprLen;
@@ -299,10 +393,9 @@ void test_large_deflate(compr, comprLen, uncompr, uncomprLen)
     c_stream.next_in = uncompr;
     c_stream.avail_in = (uInt)uncomprLen;
     err = deflate(&c_stream, Z_NO_FLUSH);
-    CHECK_ERR(err, "deflate");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "deflate", result);
     if (c_stream.avail_in != 0) {
-        fprintf(stderr, "deflate not greedy\n");
-        exit(1);
+        RETURN_WITH_MESSAGE("deflate not greedy\n", result);
     }
 
     /* Feed in already compressed data and switch to no compression: */
@@ -310,33 +403,37 @@ void test_large_deflate(compr, comprLen, uncompr, uncomprLen)
     c_stream.next_in = compr;
     c_stream.avail_in = (uInt)comprLen/2;
     err = deflate(&c_stream, Z_NO_FLUSH);
-    CHECK_ERR(err, "deflate");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "deflate", result);
 
     /* Switch back to compressing mode: */
     deflateParams(&c_stream, Z_BEST_COMPRESSION, Z_FILTERED);
     c_stream.next_in = uncompr;
     c_stream.avail_in = (uInt)uncomprLen;
     err = deflate(&c_stream, Z_NO_FLUSH);
-    CHECK_ERR(err, "deflate");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "deflate", result);
 
     err = deflate(&c_stream, Z_FINISH);
     if (err != Z_STREAM_END) {
-        fprintf(stderr, "deflate should report Z_STREAM_END\n");
-        exit(1);
+        RETURN_WITH_MESSAGE("deflate should report Z_STREAM_END\n", result);
     }
     err = deflateEnd(&c_stream);
-    CHECK_ERR(err, "deflateEnd");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "deflateEnd", result);
+
+    result.result = SUCCESSFUL;
+    result.message = NULL;
+    return result;
 }
 
 /* ===========================================================================
  * Test inflate() with large buffers
  */
-void test_large_inflate(compr, comprLen, uncompr, uncomprLen)
+test_result test_large_inflate(compr, comprLen, uncompr, uncomprLen)
     Byte *compr, *uncompr;
     uLong comprLen, uncomprLen;
 {
     int err;
     z_stream d_stream; /* decompression stream */
+    test_result result;
 
     strcpy((char*)uncompr, "garbage");
 
@@ -348,74 +445,86 @@ void test_large_inflate(compr, comprLen, uncompr, uncomprLen)
     d_stream.avail_in = (uInt)comprLen;
 
     err = inflateInit(&d_stream);
-    CHECK_ERR(err, "inflateInit");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "inflateInit", result);
 
     for (;;) {
         d_stream.next_out = uncompr;            /* discard the output */
         d_stream.avail_out = (uInt)uncomprLen;
         err = inflate(&d_stream, Z_NO_FLUSH);
         if (err == Z_STREAM_END) break;
-        CHECK_ERR(err, "large inflate");
+        RETURN_ON_ERROR_WITH_MESSAGE(err, "large inflate", result);
     }
 
     err = inflateEnd(&d_stream);
-    CHECK_ERR(err, "inflateEnd");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "inflateEnd", result);
 
     if (d_stream.total_out != 2*uncomprLen + comprLen/2) {
-        fprintf(stderr, "bad large inflate: %ld\n", d_stream.total_out);
-        exit(1);
+        sprintf(string_buffer, "bad large inflate: %ld\n", d_stream.total_out);
+        result.result = FAILED_WITHOUT_ERROR_CODE;
+        result.line_number = __LINE__;
+        result.message = string_buffer;
+        return result;
     } else {
-        printf("large_inflate(): OK\n");
+        result.result = SUCCESSFUL;
+        result.message = "large_inflate(): OK\n";
+        result.extended_message = NULL;
+        return result;
     }
 }
 
 /* ===========================================================================
  * Test deflate() with full flush
  */
-void test_flush(compr, comprLen)
+test_result test_flush(compr, comprLen)
     Byte *compr;
     uLong *comprLen;
 {
     z_stream c_stream; /* compression stream */
     int err;
     uInt len = (uInt)strlen(hello)+1;
+    test_result result;
 
     c_stream.zalloc = zalloc;
     c_stream.zfree = zfree;
     c_stream.opaque = (voidpf)0;
 
     err = deflateInit(&c_stream, Z_DEFAULT_COMPRESSION);
-    CHECK_ERR(err, "deflateInit");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "deflateInit", result);
 
     c_stream.next_in  = (z_const unsigned char *)hello;
     c_stream.next_out = compr;
     c_stream.avail_in = 3;
     c_stream.avail_out = (uInt)*comprLen;
     err = deflate(&c_stream, Z_FULL_FLUSH);
-    CHECK_ERR(err, "deflate");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "deflate", result);
 
     compr[3]++; /* force an error in first compressed block */
     c_stream.avail_in = len - 3;
 
     err = deflate(&c_stream, Z_FINISH);
     if (err != Z_STREAM_END) {
-        CHECK_ERR(err, "deflate");
+        RETURN_ON_ERROR_WITH_MESSAGE(err, "deflate", result);
     }
     err = deflateEnd(&c_stream);
-    CHECK_ERR(err, "deflateEnd");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "deflateEnd", result);
 
     *comprLen = c_stream.total_out;
+
+    result.result = SUCCESSFUL;
+    result.message = NULL;
+    return result;
 }
 
 /* ===========================================================================
  * Test inflateSync()
  */
-void test_sync(compr, comprLen, uncompr, uncomprLen)
+test_result test_sync(compr, comprLen, uncompr, uncomprLen)
     Byte *compr, *uncompr;
     uLong comprLen, uncomprLen;
 {
     int err;
     z_stream d_stream; /* decompression stream */
+    test_result result;
 
     strcpy((char*)uncompr, "garbage");
 
@@ -427,49 +536,52 @@ void test_sync(compr, comprLen, uncompr, uncomprLen)
     d_stream.avail_in = 2; /* just read the zlib header */
 
     err = inflateInit(&d_stream);
-    CHECK_ERR(err, "inflateInit");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "inflateInit", result);
 
     d_stream.next_out = uncompr;
     d_stream.avail_out = (uInt)uncomprLen;
 
     err = inflate(&d_stream, Z_NO_FLUSH);
-    CHECK_ERR(err, "inflate");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "inflate", result);
 
     d_stream.avail_in = (uInt)comprLen-2;   /* read all compressed data */
     err = inflateSync(&d_stream);           /* but skip the damaged part */
-    CHECK_ERR(err, "inflateSync");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "inflateSync", result);
 
     err = inflate(&d_stream, Z_FINISH);
     if (err != Z_STREAM_END) {
-        fprintf(stderr, "inflate should report Z_STREAM_END\n");
-        exit(1);
+        RETURN_WITH_MESSAGE("inflate should report Z_STREAM_END\n", result);
     }
     err = inflateEnd(&d_stream);
-    CHECK_ERR(err, "inflateEnd");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "inflateEnd", result);
 
-    printf("after inflateSync(): hel%s\n", (char *)uncompr);
+    result.result = SUCCESSFUL;
+    result.message = "after inflateSync(): hel";
+    result.extended_message = (char*)uncompr;
+    return result;
 }
 
 /* ===========================================================================
  * Test deflate() with preset dictionary
  */
-void test_dict_deflate(compr, comprLen)
+test_result test_dict_deflate(compr, comprLen)
     Byte *compr;
     uLong comprLen;
 {
     z_stream c_stream; /* compression stream */
     int err;
+    test_result result;
 
     c_stream.zalloc = zalloc;
     c_stream.zfree = zfree;
     c_stream.opaque = (voidpf)0;
 
     err = deflateInit(&c_stream, Z_BEST_COMPRESSION);
-    CHECK_ERR(err, "deflateInit");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "deflateInit", result);
 
     err = deflateSetDictionary(&c_stream,
                 (const Bytef*)dictionary, (int)sizeof(dictionary));
-    CHECK_ERR(err, "deflateSetDictionary");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "deflateSetDictionary", result);
 
     dictId = c_stream.adler;
     c_stream.next_out = compr;
@@ -480,22 +592,26 @@ void test_dict_deflate(compr, comprLen)
 
     err = deflate(&c_stream, Z_FINISH);
     if (err != Z_STREAM_END) {
-        fprintf(stderr, "deflate should report Z_STREAM_END\n");
-        exit(1);
+        RETURN_WITH_MESSAGE("deflate should report Z_STREAM_END\n", result);
     }
     err = deflateEnd(&c_stream);
-    CHECK_ERR(err, "deflateEnd");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "deflateEnd", result);
+
+    result.result = SUCCESSFUL;
+    result.message = NULL;
+    return result;
 }
 
 /* ===========================================================================
  * Test inflate() with a preset dictionary
  */
-void test_dict_inflate(compr, comprLen, uncompr, uncomprLen)
+test_result test_dict_inflate(compr, comprLen, uncompr, uncomprLen)
     Byte *compr, *uncompr;
     uLong comprLen, uncomprLen;
 {
     int err;
     z_stream d_stream; /* decompression stream */
+    test_result result;
 
     strcpy((char*)uncompr, "garbage");
 
@@ -507,7 +623,7 @@ void test_dict_inflate(compr, comprLen, uncompr, uncomprLen)
     d_stream.avail_in = (uInt)comprLen;
 
     err = inflateInit(&d_stream);
-    CHECK_ERR(err, "inflateInit");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "inflateInit", result);
 
     d_stream.next_out = uncompr;
     d_stream.avail_out = (uInt)uncomprLen;
@@ -523,22 +639,24 @@ void test_dict_inflate(compr, comprLen, uncompr, uncomprLen)
             err = inflateSetDictionary(&d_stream, (const Bytef*)dictionary,
                                        (int)sizeof(dictionary));
         }
-        CHECK_ERR(err, "inflate with dict");
+        RETURN_ON_ERROR_WITH_MESSAGE(err, "inflate with dict", result);
     }
 
     err = inflateEnd(&d_stream);
-    CHECK_ERR(err, "inflateEnd");
+    RETURN_ON_ERROR_WITH_MESSAGE(err, "inflateEnd", result);
 
     if (strcmp((char*)uncompr, hello)) {
-        fprintf(stderr, "bad inflate with dict\n");
-        exit(1);
+        RETURN_WITH_MESSAGE("bad inflate with dict\n", result);
     } else {
-        printf("inflate with dictionary: %s\n", (char *)uncompr);
+        result.result = SUCCESSFUL;
+        result.message = "inflate with dictionary: ";
+        result.extended_message = (char*)uncompr;
+        return result;
     }
 }
 
 /* ===========================================================================
- * Usage:  example [output.gz  [input.gz]]
+ * Usage:  example [--junit results.xml] [output.gz  [input.gz]]
  */
 
 int main(argc, argv)
@@ -549,11 +667,15 @@ int main(argc, argv)
     uLong comprLen = 10000*sizeof(int); /* don't overflow on MSDOS */
     uLong uncomprLen = comprLen;
     static const char* myVersion = ZLIB_VERSION;
+    test_result result;
+    int is_junit_output = 0;
+    FILE* output = stdout;
+    int next_argv_index = 1;
+    int failed_test_count = 0;
 
     if (zlibVersion()[0] != myVersion[0]) {
         fprintf(stderr, "incompatible zlib version\n");
         exit(1);
-
     } else if (strcmp(zlibVersion(), ZLIB_VERSION) != 0) {
         fprintf(stderr, "warning: different zlib version\n");
     }
@@ -575,27 +697,65 @@ int main(argc, argv)
     (void)argc;
     (void)argv;
 #else
-    test_compress(compr, comprLen, uncompr, uncomprLen);
+    if (argc > 1) {
+        if (strcmp(argv[1], "--junit") == 0) {
+            if (argc <= 2) {
+                fprintf(stderr, "--junit flag requires an output file parameter, like --junit output.xml");
+                exit(1);
+            }
+            next_argv_index += 2;
+            is_junit_output = 1;
 
-    test_gzio((argc > 1 ? argv[1] : TESTFILE),
-              uncompr, uncomprLen);
+            output = fopen(argv[2], "w+");
+            if (!output) {
+                fprintf(stderr, "Could not open junit file");
+                exit(1);
+            }
+            fprintf(output, "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n");
+            fprintf(output, "<testsuites>\n");
+            fprintf(output, "\t<testsuite name=\"zlib example suite\">\n");
+        }
+    }
+
+    result = test_compress(compr, comprLen, uncompr, uncomprLen);
+    handle_test_results(output, result, "compress", is_junit_output, &failed_test_count);
+	
+    result = test_gzio((argc > next_argv_index ? argv[next_argv_index++] : TESTFILE),
+                       uncompr, uncomprLen);
+    handle_test_results(output, result, "gzio", is_junit_output, &failed_test_count);
 #endif
 
-    test_deflate(compr, comprLen);
-    test_inflate(compr, comprLen, uncompr, uncomprLen);
+    result = test_deflate(compr, comprLen);
+    handle_test_results(output, result, "deflate", is_junit_output, &failed_test_count);
+    result = test_inflate(compr, comprLen, uncompr, uncomprLen);
+    handle_test_results(output, result, "inflate", is_junit_output, &failed_test_count);
 
-    test_large_deflate(compr, comprLen, uncompr, uncomprLen);
-    test_large_inflate(compr, comprLen, uncompr, uncomprLen);
+    result = test_large_deflate(compr, comprLen, uncompr, uncomprLen);
+    handle_test_results(output, result, "large deflate", is_junit_output, &failed_test_count);
+    result = test_large_inflate(compr, comprLen, uncompr, uncomprLen);
+    handle_test_results(output, result, "large inflate", is_junit_output, &failed_test_count);
 
-    test_flush(compr, &comprLen);
-    test_sync(compr, comprLen, uncompr, uncomprLen);
+    result = test_flush(compr, &comprLen);
+    handle_test_results(output, result, "flush", is_junit_output, &failed_test_count);
+    result = test_sync(compr, comprLen, uncompr, uncomprLen);
+    handle_test_results(output, result, "sync", is_junit_output, &failed_test_count);
     comprLen = uncomprLen;
 
-    test_dict_deflate(compr, comprLen);
-    test_dict_inflate(compr, comprLen, uncompr, uncomprLen);
+    result = test_dict_deflate(compr, comprLen);
+    handle_test_results(output, result, "dict deflate", is_junit_output, &failed_test_count);
+    result = test_dict_inflate(compr, comprLen, uncompr, uncomprLen);
+    handle_test_results(output, result, "dict inflate", is_junit_output, &failed_test_count);
 
+    if (is_junit_output) {
+        fprintf(output, "\t</testsuite>\n");
+        fprintf(output, "</testsuites>");
+        fclose(output);
+    }
     free(compr);
     free(uncompr);
 
+    if (failed_test_count) {
+        return 1;
+    }
     return 0;
 }

--- a/test/example.c
+++ b/test/example.c
@@ -58,6 +58,16 @@ char string_buffer[STRING_BUFFER_SIZE];
     } \
 }
 
+#define RETURN_SUCCESS(_message, _extended_message) { \
+    { \
+        test_result result; \
+        result.result = SUCCESSFUL; \
+        result.message = _message; \
+        result.extended_message = _extended_message; \
+        return result; \
+    } \
+}
+
 void handle_test_results(FILE* output, test_result result, z_const char* testcase_name, int is_junit_output, int* failed_test_count) {
     if (is_junit_output) {
         fprintf(output, "\t\t<testcase name=\"%s\">", testcase_name);
@@ -181,11 +191,7 @@ test_result test_compress(compr, comprLen, uncompr, uncomprLen)
     if (strcmp((char*)uncompr, hello)) {
         RETURN_WITH_MESSAGE("bad uncompress\n", NULL);
     } else {
-        test_result result;
-        result.result = SUCCESSFUL;
-        result.message = "uncompress(): ";
-        result.extended_message = (char*)uncompr;
-        return result;
+        RETURN_SUCCESS("uncompress(): ", (char*)uncompr);
     }
 }
 
@@ -269,10 +275,7 @@ test_result test_gzio(fname, uncompr, uncomprLen)
     gzclose(file);
 
 	{
-        test_result result;
-        result.result = SUCCESSFUL;
-        result.message = NULL;
-        return result;
+        RETURN_SUCCESS(NULL, NULL);
 	}
 #endif
 }
@@ -317,10 +320,7 @@ test_result test_deflate(compr, comprLen)
     RETURN_ON_ERROR_WITH_MESSAGE(err, "deflateEnd");
 
 	{
-        test_result result;
-        result.result = SUCCESSFUL;
-        result.message = NULL;
-        return result;
+        RETURN_SUCCESS(NULL, NULL);
 	}
 }
 
@@ -360,11 +360,7 @@ test_result test_inflate(compr, comprLen, uncompr, uncomprLen)
     if (strcmp((char*)uncompr, hello)) {
         RETURN_WITH_MESSAGE("bad inflate\n", NULL);
     } else {
-        test_result result;
-        result.result = SUCCESSFUL;
-        result.message = "inflate(): ";
-        result.extended_message = (char*)uncompr;
-        return result;
+        RETURN_SUCCESS("inflate(): ", (char*)uncompr);
     }
 }
 
@@ -421,10 +417,7 @@ test_result test_large_deflate(compr, comprLen, uncompr, uncomprLen)
     RETURN_ON_ERROR_WITH_MESSAGE(err, "deflateEnd");
 
 	{
-        test_result result;
-        result.result = SUCCESSFUL;
-        result.message = NULL;
-        return result;
+        RETURN_SUCCESS(NULL, NULL);
 	}
 }
 
@@ -469,11 +462,7 @@ test_result test_large_inflate(compr, comprLen, uncompr, uncomprLen)
         result.message = string_buffer;
         return result;
     } else {
-        test_result result;
-        result.result = SUCCESSFUL;
-        result.message = "large_inflate(): OK\n";
-        result.extended_message = NULL;
-        return result;
+        RETURN_SUCCESS("large_inflate(): OK\n", NULL);
     }
 }
 
@@ -515,10 +504,7 @@ test_result test_flush(compr, comprLen)
     *comprLen = c_stream.total_out;
 
 	{
-        test_result result;
-        result.result = SUCCESSFUL;
-        result.message = NULL;
-        return result;
+        RETURN_SUCCESS(NULL, NULL);
 	}
 }
 
@@ -562,11 +548,7 @@ test_result test_sync(compr, comprLen, uncompr, uncomprLen)
     RETURN_ON_ERROR_WITH_MESSAGE(err, "inflateEnd");
 
 	{
-        test_result result;
-        result.result = SUCCESSFUL;
-        result.message = "after inflateSync(): hel";
-        result.extended_message = (char*)uncompr;
-        return result;
+        RETURN_SUCCESS("after inflateSync(): hel", (char*)uncompr);
 	}
 }
 
@@ -606,10 +588,7 @@ test_result test_dict_deflate(compr, comprLen)
     RETURN_ON_ERROR_WITH_MESSAGE(err, "deflateEnd");
 
 	{
-        test_result result;
-        result.result = SUCCESSFUL;
-        result.message = NULL;
-        return result;
+        RETURN_SUCCESS(NULL, NULL);
 	}
 }
 
@@ -658,11 +637,7 @@ test_result test_dict_inflate(compr, comprLen, uncompr, uncomprLen)
     if (strcmp((char*)uncompr, hello)) {
         RETURN_WITH_MESSAGE("bad inflate with dict\n", NULL);
     } else {
-        test_result result;
-        result.result = SUCCESSFUL;
-        result.message = "inflate with dictionary: ";
-        result.extended_message = (char*)uncompr;
-        return result;
+        RETURN_SUCCESS("inflate with dictionary: ", (char*)uncompr);
     }
 }
 

--- a/test/example.c
+++ b/test/example.c
@@ -64,7 +64,15 @@ char string_buffer[STRING_BUFFER_SIZE];
     return result; \
 }
 
-void handle_test_results(FILE* output, test_result result, z_const char* testcase_name, int is_junit_output, int* failed_test_count) {
+void handle_test_results OF((FILE* output, test_result result, z_const char* testcase_name, int is_junit_output, int* failed_test_count));
+
+void handle_test_results(output, result, testcase_name, is_junit_output, failed_test_count)
+    FILE* output;
+    test_result result;
+    z_const char* testcase_name;
+    int is_junit_output;
+    int* failed_test_count;
+{
     if (is_junit_output) {
         fprintf(output, "\t\t<testcase name=\"%s\">", testcase_name);
     }

--- a/test/example.c
+++ b/test/example.c
@@ -204,10 +204,7 @@ test_result test_gzio(fname, uncompr, uncomprLen)
     uLong uncomprLen;
 {
 #ifdef NO_GZCOMPRESS
-    test_result result;
-    result.success = FAILED_WITHOUT_ERROR_CODE;
-    result.message = "NO_GZCOMPRESS -- gz* functions cannot compress";
-    return result;
+    RETURN_WITH_MESSAGE("NO_GZCOMPRESS -- gz* functions cannot compress", NULL);
 #else
     int err;
     int len = (int)strlen(hello)+1;

--- a/test/example.c
+++ b/test/example.c
@@ -24,13 +24,13 @@
 #define FAILED_WITHOUT_ERROR_CODE -1
 
 typedef struct test_result_s {
-    int           result; /* One of: SUCCESSFUL,
-                          FAILED_WITH_ERROR_CODE, or
-                          FAILED_WITHOUT_ERROR_CODE*/
-    int           error_code; /* error code if success is FAILED_WITH_ERROR_CODE */
-    int           line_number;
-    z_const char* message;
-    z_const char* extended_message;
+    int         result; /* One of: SUCCESSFUL,
+                           FAILED_WITH_ERROR_CODE, or
+                           FAILED_WITHOUT_ERROR_CODE*/
+    int         error_code; /* error code if success is FAILED_WITH_ERROR_CODE */
+    int         line_number;
+    const char* message;
+    const char* extended_message;
 } test_result;
 
 #define STRING_BUFFER_SIZE 100

--- a/test/example.c
+++ b/test/example.c
@@ -105,7 +105,7 @@ void handle_test_results(output, result, testcase_name, is_junit_output, failed_
         if (!is_junit_output) {
             if (result.message != NULL) {
                 if (result.extended_message != NULL) {
-                    fprintf(output, "%s%s\n", result.message, result.extended_message);
+                    fprintf(stderr, "%s%s\n", result.message, result.extended_message);
                 } else {
                     fprintf(stderr, "%s", result.message);
                 }

--- a/test/example.c
+++ b/test/example.c
@@ -48,24 +48,20 @@ char string_buffer[STRING_BUFFER_SIZE];
 }
 
 #define RETURN_WITH_MESSAGE(_message, _extended_message) { \
-    { \
-        test_result result; \
-        result.result = FAILED_WITHOUT_ERROR_CODE; \
-        result.line_number = __LINE__; \
-        result.message = _message; \
-        result.extended_message = _extended_message; \
-        return result; \
-    } \
+    test_result result; \
+    result.result = FAILED_WITHOUT_ERROR_CODE; \
+    result.line_number = __LINE__; \
+    result.message = _message; \
+    result.extended_message = _extended_message; \
+    return result; \
 }
 
 #define RETURN_SUCCESS(_message, _extended_message) { \
-    { \
-        test_result result; \
-        result.result = SUCCESSFUL; \
-        result.message = _message; \
-        result.extended_message = _extended_message; \
-        return result; \
-    } \
+    test_result result; \
+    result.result = SUCCESSFUL; \
+    result.message = _message; \
+    result.extended_message = _extended_message; \
+    return result; \
 }
 
 void handle_test_results(FILE* output, test_result result, z_const char* testcase_name, int is_junit_output, int* failed_test_count) {

--- a/test/example.c
+++ b/test/example.c
@@ -47,17 +47,7 @@ char string_buffer[STRING_BUFFER_SIZE];
     } \
 }
 
-#define RETURN_WITH_MESSAGE(_message) { \
-    { \
-        test_result result; \
-        result.result = FAILED_WITHOUT_ERROR_CODE; \
-        result.line_number = __LINE__; \
-        result.message = _message; \
-        return result; \
-    } \
-}
-
-#define RETURN_WITH_EXTENDED_MESSAGE(_message, _extended_message) { \
+#define RETURN_WITH_MESSAGE(_message, _extended_message) { \
     { \
         test_result result; \
         result.result = FAILED_WITHOUT_ERROR_CODE; \
@@ -189,7 +179,7 @@ test_result test_compress(compr, comprLen, uncompr, uncomprLen)
     RETURN_ON_ERROR_WITH_MESSAGE(err, "uncompress");
 
     if (strcmp((char*)uncompr, hello)) {
-        RETURN_WITH_MESSAGE("bad uncompress\n");
+        RETURN_WITH_MESSAGE("bad uncompress\n", NULL);
     } else {
         test_result result;
         result.result = SUCCESSFUL;
@@ -220,29 +210,29 @@ test_result test_gzio(fname, uncompr, uncomprLen)
 
     file = gzopen(fname, "wb");
     if (file == NULL) {
-        RETURN_WITH_MESSAGE("gzopen error");
+        RETURN_WITH_MESSAGE("gzopen error", NULL);
     }
     gzputc(file, 'h');
     if (gzputs(file, "ello") != 4) {
-        RETURN_WITH_EXTENDED_MESSAGE("gzputs err: ", gzerror(file, &err));
+        RETURN_WITH_MESSAGE("gzputs err: ", gzerror(file, &err));
     }
     if (gzprintf(file, ", %s!", "hello") != 8) {
-        RETURN_WITH_EXTENDED_MESSAGE("gzprintf err: ", gzerror(file, &err));
+        RETURN_WITH_MESSAGE("gzprintf err: ", gzerror(file, &err));
     }
     gzseek(file, 1L, SEEK_CUR); /* add one zero byte */
     gzclose(file);
 
     file = gzopen(fname, "rb");
     if (file == NULL) {
-        RETURN_WITH_MESSAGE("gzopen error");
+        RETURN_WITH_MESSAGE("gzopen error", NULL);
     }
     strcpy((char*)uncompr, "garbage");
 
     if (gzread(file, uncompr, (unsigned)uncomprLen) != len) {
-        RETURN_WITH_EXTENDED_MESSAGE("gzread err: ", gzerror(file, &err));
+        RETURN_WITH_MESSAGE("gzread err: ", gzerror(file, &err));
     }
     if (strcmp((char*)uncompr, hello)) {
-        RETURN_WITH_EXTENDED_MESSAGE("bad gzread: ", (char*)uncompr);
+        RETURN_WITH_MESSAGE("bad gzread: ", (char*)uncompr);
     } else {
         printf("gzread(): %s\n", (char*)uncompr);
     }
@@ -259,19 +249,19 @@ test_result test_gzio(fname, uncompr, uncomprLen)
     }
 
     if (gzgetc(file) != ' ') {
-        RETURN_WITH_MESSAGE("gzgetc error");
+        RETURN_WITH_MESSAGE("gzgetc error", NULL);
     }
 
     if (gzungetc(' ', file) != ' ') {
-        RETURN_WITH_MESSAGE("gzungetc error");
+        RETURN_WITH_MESSAGE("gzungetc error", NULL);
     }
 
     gzgets(file, (char*)uncompr, (int)uncomprLen);
     if (strlen((char*)uncompr) != 7) { /* " hello!" */
-        RETURN_WITH_EXTENDED_MESSAGE("gzgets err after gzseek: ", gzerror(file, &err));
+        RETURN_WITH_MESSAGE("gzgets err after gzseek: ", gzerror(file, &err));
     }
     if (strcmp((char*)uncompr, hello + 6)) {
-        RETURN_WITH_MESSAGE("bad gzgets after gzseek");
+        RETURN_WITH_MESSAGE("bad gzgets after gzseek", NULL);
     } else {
         printf("gzgets() after gzseek: %s\n", (char*)uncompr);
     }
@@ -368,7 +358,7 @@ test_result test_inflate(compr, comprLen, uncompr, uncomprLen)
     RETURN_ON_ERROR_WITH_MESSAGE(err, "inflateEnd");
 
     if (strcmp((char*)uncompr, hello)) {
-        RETURN_WITH_MESSAGE("bad inflate\n");
+        RETURN_WITH_MESSAGE("bad inflate\n", NULL);
     } else {
         test_result result;
         result.result = SUCCESSFUL;
@@ -406,7 +396,7 @@ test_result test_large_deflate(compr, comprLen, uncompr, uncomprLen)
     err = deflate(&c_stream, Z_NO_FLUSH);
     RETURN_ON_ERROR_WITH_MESSAGE(err, "deflate");
     if (c_stream.avail_in != 0) {
-        RETURN_WITH_MESSAGE("deflate not greedy\n");
+        RETURN_WITH_MESSAGE("deflate not greedy\n", NULL);
     }
 
     /* Feed in already compressed data and switch to no compression: */
@@ -425,7 +415,7 @@ test_result test_large_deflate(compr, comprLen, uncompr, uncomprLen)
 
     err = deflate(&c_stream, Z_FINISH);
     if (err != Z_STREAM_END) {
-        RETURN_WITH_MESSAGE("deflate should report Z_STREAM_END\n");
+        RETURN_WITH_MESSAGE("deflate should report Z_STREAM_END\n", NULL);
     }
     err = deflateEnd(&c_stream);
     RETURN_ON_ERROR_WITH_MESSAGE(err, "deflateEnd");
@@ -566,7 +556,7 @@ test_result test_sync(compr, comprLen, uncompr, uncomprLen)
 
     err = inflate(&d_stream, Z_FINISH);
     if (err != Z_STREAM_END) {
-        RETURN_WITH_MESSAGE("inflate should report Z_STREAM_END\n");
+        RETURN_WITH_MESSAGE("inflate should report Z_STREAM_END\n", NULL);
     }
     err = inflateEnd(&d_stream);
     RETURN_ON_ERROR_WITH_MESSAGE(err, "inflateEnd");
@@ -610,7 +600,7 @@ test_result test_dict_deflate(compr, comprLen)
 
     err = deflate(&c_stream, Z_FINISH);
     if (err != Z_STREAM_END) {
-        RETURN_WITH_MESSAGE("deflate should report Z_STREAM_END\n");
+        RETURN_WITH_MESSAGE("deflate should report Z_STREAM_END\n", NULL);
     }
     err = deflateEnd(&c_stream);
     RETURN_ON_ERROR_WITH_MESSAGE(err, "deflateEnd");
@@ -666,7 +656,7 @@ test_result test_dict_inflate(compr, comprLen, uncompr, uncomprLen)
     RETURN_ON_ERROR_WITH_MESSAGE(err, "inflateEnd");
 
     if (strcmp((char*)uncompr, hello)) {
-        RETURN_WITH_MESSAGE("bad inflate with dict\n");
+        RETURN_WITH_MESSAGE("bad inflate with dict\n", NULL);
     } else {
         test_result result;
         result.result = SUCCESSFUL;

--- a/test/example.c
+++ b/test/example.c
@@ -43,6 +43,7 @@ char string_buffer[STRING_BUFFER_SIZE];
         result.error_code = _error_code; \
         result.line_number = __LINE__; \
         result.message = _message; \
+        result.extended_message = NULL; \
         return result; \
     } \
 }
@@ -50,6 +51,7 @@ char string_buffer[STRING_BUFFER_SIZE];
 #define RETURN_FAILURE(_message, _extended_message) { \
     test_result result; \
     result.result = FAILED_WITHOUT_ERROR_CODE; \
+    result.error_code = Z_OK; \
     result.line_number = __LINE__; \
     result.message = _message; \
     result.extended_message = _extended_message; \
@@ -59,6 +61,7 @@ char string_buffer[STRING_BUFFER_SIZE];
 #define RETURN_SUCCESS(_message, _extended_message) { \
     test_result result; \
     result.result = SUCCESSFUL; \
+    result.error_code = Z_OK; \
     result.message = _message; \
     result.extended_message = _extended_message; \
     return result; \
@@ -250,8 +253,10 @@ test_result test_gzio(fname, uncompr, uncomprLen)
         sprintf(string_buffer, "gzseek error, pos=%ld, gztell=%ld\n",
                 (long)pos, (long)gztell(file));
         result.result = FAILED_WITHOUT_ERROR_CODE;
+        result.error_code = Z_OK;
         result.line_number = __LINE__;
         result.message = string_buffer;
+        result.extended_message = NULL;
         return result;
     }
 
@@ -459,8 +464,10 @@ test_result test_large_inflate(compr, comprLen, uncompr, uncomprLen)
         test_result result;
         sprintf(string_buffer, "bad large inflate: %ld\n", d_stream.total_out);
         result.result = FAILED_WITHOUT_ERROR_CODE;
+        result.error_code = Z_OK;
         result.line_number = __LINE__;
         result.message = string_buffer;
+        result.extended_message = NULL;
         return result;
     } else {
         RETURN_SUCCESS("large_inflate(): OK\n", NULL);

--- a/test/example.c
+++ b/test/example.c
@@ -23,6 +23,10 @@
 #define FAILED_WITH_ERROR_CODE     0
 #define FAILED_WITHOUT_ERROR_CODE -1
 
+const char *g_junit_ofname;
+FILE *g_junit_output;
+int g_failed_test_count;
+
 typedef struct test_result_s {
     int         result; /* One of: SUCCESSFUL,
                            FAILED_WITH_ERROR_CODE, or
@@ -67,21 +71,21 @@ char string_buffer[STRING_BUFFER_SIZE];
     return result; \
 }
 
-void handle_test_results OF((FILE* output, test_result result, z_const char* testcase_name, int is_junit_output, int* failed_test_count));
+void handle_test_results OF((test_result result, z_const char* testcase_name));
 
-void handle_test_results(output, result, testcase_name, is_junit_output, failed_test_count)
-    FILE* output;
+void handle_test_results(result, testcase_name)
     test_result result;
     z_const char* testcase_name;
-    int is_junit_output;
-    int* failed_test_count;
 {
+    int is_junit_output = (g_junit_output != NULL);
+    FILE *output = g_junit_output;
+
     if (is_junit_output) {
         fprintf(output, "\t\t<testcase name=\"%s\">", testcase_name);
     }
 
     if (result.result == FAILED_WITH_ERROR_CODE) {
-        (*failed_test_count)++;
+        g_failed_test_count++;
         if (is_junit_output) {
             fprintf(output, "\n\t\t\t<failure file=\"%s\" line=\"%d\">%s error: %d</failure>\n\t\t", __FILE__, result.line_number, result.message, result.error_code);
         } else {
@@ -89,7 +93,7 @@ void handle_test_results(output, result, testcase_name, is_junit_output, failed_
             exit(1);
         }
     } else if (result.result == FAILED_WITHOUT_ERROR_CODE) {
-        (*failed_test_count)++;
+        g_failed_test_count++;
         if (is_junit_output) {
             fprintf(output, "\n\t\t\t<failure file=\"%s\" line=\"%d\">%s", __FILE__, result.line_number, result.message);
             if (result.extended_message != NULL) {
@@ -662,10 +666,7 @@ int main(argc, argv)
     uLong uncomprLen = comprLen;
     static const char* myVersion = ZLIB_VERSION;
     test_result result;
-    int is_junit_output = 0;
-    FILE* output = stdout;
     int next_argv_index = 1;
-    int failed_test_count = 0;
 
     if (zlibVersion()[0] != myVersion[0]) {
         fprintf(stderr, "incompatible zlib version\n");
@@ -687,68 +688,77 @@ int main(argc, argv)
         exit(1);
     }
 
+    /* If an option is specified both by an environment variable and by
+     * a flag, the latter takes precedence.
+     */
+    g_junit_ofname = getenv("ZLIBTEST_JUNIT");
+    while (next_argv_index < argc && !strncmp(argv[next_argv_index], "--", 2)) {
+        if (strcmp(argv[next_argv_index], "--junit") == 0) {
+            next_argv_index++;
+            if (argc <= next_argv_index) {
+                fprintf(stderr, "--junit flag requires an output file parameter, like --junit output.xml\n");
+                exit(1);
+            }
+            g_junit_ofname = argv[next_argv_index];
+            next_argv_index++;
+        } else {
+            fprintf(stderr, "Unrecognized option %s\n", argv[next_argv_index]);
+            exit(1);
+        }
+    }
+    if (g_junit_ofname) {
+        g_junit_output = fopen(g_junit_ofname, "w+");
+        if (!g_junit_output) {
+            fprintf(stderr, "Could not open junit file %s\n", g_junit_ofname);
+            exit(1);
+        }
+        fprintf(g_junit_output, "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n");
+        fprintf(g_junit_output, "<testsuites>\n");
+        fprintf(g_junit_output, "\t<testsuite name=\"zlib example suite\">\n");
+    }
+
 #ifdef Z_SOLO
     (void)argc;
     (void)argv;
 #else
-    if (argc > 1) {
-        if (strcmp(argv[1], "--junit") == 0) {
-            if (argc <= 2) {
-                fprintf(stderr, "--junit flag requires an output file parameter, like --junit output.xml");
-                exit(1);
-            }
-            next_argv_index += 2;
-            is_junit_output = 1;
-
-            output = fopen(argv[2], "w+");
-            if (!output) {
-                fprintf(stderr, "Could not open junit file");
-                exit(1);
-            }
-            fprintf(output, "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n");
-            fprintf(output, "<testsuites>\n");
-            fprintf(output, "\t<testsuite name=\"zlib example suite\">\n");
-        }
-    }
-
     result = test_compress(compr, comprLen, uncompr, uncomprLen);
-    handle_test_results(output, result, "compress", is_junit_output, &failed_test_count);
+    handle_test_results(result, "compress");
 	
     result = test_gzio((argc > next_argv_index ? argv[next_argv_index++] : TESTFILE),
                        uncompr, uncomprLen);
-    handle_test_results(output, result, "gzio", is_junit_output, &failed_test_count);
+    handle_test_results(result, "gzio");
 #endif
 
     result = test_deflate(compr, comprLen);
-    handle_test_results(output, result, "deflate", is_junit_output, &failed_test_count);
+    handle_test_results(result, "deflate");
     result = test_inflate(compr, comprLen, uncompr, uncomprLen);
-    handle_test_results(output, result, "inflate", is_junit_output, &failed_test_count);
+    handle_test_results(result, "inflate");
 
     result = test_large_deflate(compr, comprLen, uncompr, uncomprLen);
-    handle_test_results(output, result, "large deflate", is_junit_output, &failed_test_count);
+    handle_test_results(result, "large deflate");
     result = test_large_inflate(compr, comprLen, uncompr, uncomprLen);
-    handle_test_results(output, result, "large inflate", is_junit_output, &failed_test_count);
+    handle_test_results(result, "large inflate");
 
     result = test_flush(compr, &comprLen);
-    handle_test_results(output, result, "flush", is_junit_output, &failed_test_count);
+    handle_test_results(result, "flush");
     result = test_sync(compr, comprLen, uncompr, uncomprLen);
-    handle_test_results(output, result, "sync", is_junit_output, &failed_test_count);
+    handle_test_results(result, "sync");
     comprLen = uncomprLen;
 
     result = test_dict_deflate(compr, comprLen);
-    handle_test_results(output, result, "dict deflate", is_junit_output, &failed_test_count);
+    handle_test_results(result, "dict deflate");
     result = test_dict_inflate(compr, comprLen, uncompr, uncomprLen);
-    handle_test_results(output, result, "dict inflate", is_junit_output, &failed_test_count);
+    handle_test_results(result, "dict inflate");
 
-    if (is_junit_output) {
-        fprintf(output, "\t</testsuite>\n");
-        fprintf(output, "</testsuites>");
-        fclose(output);
+    if (g_junit_output) {
+        fprintf(g_junit_output, "\t</testsuite>\n");
+        fprintf(g_junit_output, "</testsuites>");
+        fclose(g_junit_output);
     }
     free(compr);
     free(uncompr);
 
-    if (failed_test_count) {
+    if (g_failed_test_count) {
         return 1;
     }
     return 0;

--- a/tooling/appveyor/appveyor.yml
+++ b/tooling/appveyor/appveyor.yml
@@ -22,10 +22,10 @@ configuration:
 
 test_script:
   - ps: |
-      &"$($env:APPVEYOR_BUILD_FOLDER)\$($env:CONFIGURATION)\example.exe" --junit "$($env:APPVEYOR_BUILD_FOLDER)\$($env:CONFIGURATION)\junit-results.xml"
+      & ctest -V -C $env:CONFIGURATION
       $testError = $LastExitCode
       $wc = New-Object 'System.Net.WebClient'
-      $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path "$($env:APPVEYOR_BUILD_FOLDER)\$($env:CONFIGURATION)\junit-results.xml"))
+      $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path "$($env:APPVEYOR_BUILD_FOLDER)\example-results.xml"))
       if ($testError -ne 0)
       {
         throw $testError

--- a/tooling/appveyor/appveyor.yml
+++ b/tooling/appveyor/appveyor.yml
@@ -1,0 +1,32 @@
+version: 1.2.11.1.{build}
+
+pull_requests:
+  do_not_increment_build_number: true
+
+shallow_clone: true
+
+image:
+  - Visual Studio 2019
+
+before_build:
+  - cmd: cmake .
+
+build:
+  project: "zlib.sln"
+
+platform:
+  - x64
+configuration:
+  - Debug
+  - Release
+
+test_script:
+  - ps: |
+      &"$($env:APPVEYOR_BUILD_FOLDER)\$($env:CONFIGURATION)\example.exe" --junit "$($env:APPVEYOR_BUILD_FOLDER)\$($env:CONFIGURATION)\junit-results.xml"
+      $testError = $LastExitCode
+      $wc = New-Object 'System.Net.WebClient'
+      $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path "$($env:APPVEYOR_BUILD_FOLDER)\$($env:CONFIGURATION)\junit-results.xml"))
+      if ($testError -ne 0)
+      {
+        throw $testError
+      }

--- a/tooling/cirrus/debian10/Dockerfile
+++ b/tooling/cirrus/debian10/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM debian:10
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y cmake gcc libc6-dev ninja-build make && \

--- a/tooling/cirrus/debian8/Dockerfile
+++ b/tooling/cirrus/debian8/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM debian:8
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y cmake gcc libc6-dev ninja-build make && \

--- a/tooling/cirrus/debian9/Dockerfile
+++ b/tooling/cirrus/debian9/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM debian:9
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y cmake gcc libc6-dev ninja-build make && \

--- a/tooling/cirrus/fedora31/Dockerfile
+++ b/tooling/cirrus/fedora31/Dockerfile
@@ -1,0 +1,12 @@
+FROM fedora:31
+
+RUN dnf -y update && dnf clean all
+
+RUN dnf makecache \
+  && dnf -y install \
+    gcc \
+    cmake \
+    diffutils \
+    make \
+    ninja-build \
+  && dnf clean all

--- a/tooling/cirrus/fedora32/Dockerfile
+++ b/tooling/cirrus/fedora32/Dockerfile
@@ -1,0 +1,12 @@
+FROM fedora:32
+
+RUN dnf -y update && dnf clean all
+
+RUN dnf makecache \
+  && dnf -y install \
+    gcc \
+    cmake \
+    diffutils \
+    make \
+    ninja-build \
+  && dnf clean all

--- a/tooling/cirrus/ubu1404/Dockerfile
+++ b/tooling/cirrus/ubu1404/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:14.04
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y cmake gcc libc6-dev ninja-build make && \

--- a/tooling/cirrus/ubu1604/Dockerfile
+++ b/tooling/cirrus/ubu1604/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:16.04
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y cmake gcc libc6-dev ninja-build make && \

--- a/tooling/cirrus/ubu1804/Dockerfile
+++ b/tooling/cirrus/ubu1804/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y cmake gcc libc6-dev ninja-build && \
+    apt-get install --no-install-recommends -y cmake gcc libc6-dev ninja-build make && \
     apt-get clean

--- a/tooling/cirrus/ubu1804/Dockerfile
+++ b/tooling/cirrus/ubu1804/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y cmake gcc libc6-dev ninja-build && \
+    apt-get clean

--- a/tooling/cirrus/ubu2004/Dockerfile
+++ b/tooling/cirrus/ubu2004/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:20.04
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y cmake gcc libc6-dev ninja-build && \
+    apt-get clean

--- a/tooling/cirrus/ubu2010/Dockerfile
+++ b/tooling/cirrus/ubu2010/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.10
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y cmake gcc libc6-dev ninja-build make && \

--- a/tooling/pkgcheck.sh
+++ b/tooling/pkgcheck.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# Verify that the various build systems produce identical results on a Unixlike system
+set -ex
+
+# Tell GNU's ld etc. to use Jan 1 1970 when embedding timestamps
+export SOURCE_DATE_EPOCH=0
+# Tell Apple's ar etc. to use zero timestamps
+export ZERO_AR_DATE=1
+
+# New build system
+# Happens to delete top-level zconf.h
+# (which itself is a bug, https://github.com/madler/zlib/issues/162 )
+# which triggers another bug later in configure,
+# https://github.com/madler/zlib/issues/499
+rm -rf btmp2 pkgtmp2
+mkdir btmp2 pkgtmp2
+export DESTDIR=$(pwd)/pkgtmp2
+cd btmp2
+  cmake -G Ninja ..
+  ninja -v
+  ninja install
+cd ..
+
+# Original build system
+rm -rf btmp1 pkgtmp1
+mkdir btmp1 pkgtmp1
+export DESTDIR=$(pwd)/pkgtmp1
+cd btmp1
+  case $(uname) in
+  Darwin)
+    # Tell configure which compiler etc. to use to match cmake
+    # Tell configure to pad the executable the same way cmake will
+    CC="$(xcrun --find gcc || echo gcc)" \
+    CFLAGS="-DNDEBUG -O3 -isysroot $(xcrun --show-sdk-path)" \
+    LDFLAGS="-Wl,-headerpad_max_install_names" \
+    ../configure
+    ;;
+  FreeBSD|Linux)
+    # 1) tell configure to tell ar to be deterministic (skipped, see below)
+    # 2) configure fails with cc, so use clang or gcc
+    # 3) Force same CC for configure and clang
+    #export ARFLAGS="Drc"
+    if grep -i fedora /etc/os-release > /dev/null
+    then
+        # Note: Fedora patches cmake to use -O2 in release, which
+        # does not match the -O3 configure sets :-(
+        export CFLAGS="-O2 -DNDEBUG"
+    fi
+    if clang --version
+    then
+        export CC=clang
+        ../configure
+    elif gcc --version
+    then
+        export CC=gcc
+        ../configure
+    else
+        ../configure
+    fi
+    ;;
+  *)
+    ../configure
+    ;;
+  esac
+  make
+  make install
+cd ..
+
+repack_ar() {
+  if ! cmp --silent pkgtmp1/usr/local/lib/libz.a pkgtmp2/usr/local/lib/libz.a
+  then
+    echo "Warning: libz.a does not match.  Assuming ar needs -D option.  Unpacking..."
+    cd pkgtmp1; ar x usr/local/lib/libz.a; rm usr/local/lib/libz.a; cd ..
+    cd pkgtmp2; ar x usr/local/lib/libz.a; rm usr/local/lib/libz.a; cd ..
+  fi
+}
+
+case $(uname) in
+Darwin)
+  # Alas, dylibs still have an embedded hash or something,
+  # so nuke it.
+  # FIXME: find a less fragile way to deal with this.
+  dylib1=$(find pkgtmp1 -name '*.dylib*' -type f)
+  dylib2=$(find pkgtmp2 -name '*.dylib*' -type f)
+  dd conv=notrunc if=/dev/zero of=$dylib1 skip=1337 count=16
+  dd conv=notrunc if=/dev/zero of=$dylib2 skip=1337 count=16
+  ;;
+FreeBSD|Linux)
+  # The ar on newer systems defaults to -D (i.e. deterministic),
+  # but FreeBSD 12.1, Debian 8, and Ubuntu 14.04 seem to not do that.
+  # I had trouble passing -D safely to the ar inside CMakeLists.txt,
+  # so punt and unpack the archive if needed before comparing.
+  repack_ar
+  ;;
+esac
+
+if diff -Nur pkgtmp1 pkgtmp2
+then
+  echo pkgcheck-cmake-bits-identical PASS
+else
+  echo pkgcheck-cmake-bits-identical FAIL
+  exit 1
+fi

--- a/tooling/test-cmake.sh
+++ b/tooling/test-cmake.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Build and test with CMake
+set -ex
+
+rm -rf btmp
+mkdir btmp
+cd btmp
+  cmake -G Ninja ..
+  ninja
+  ctest -V
+cd ..

--- a/tooling/test-make.sh
+++ b/tooling/test-make.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Build and test with Make
+set -ex
+
+rm -rf btmp
+mkdir btmp
+cd btmp1
+  ../configure
+  make
+  make test
+cd ..

--- a/zconf.h.cmakein
+++ b/zconf.h.cmakein
@@ -7,8 +7,6 @@
 
 #ifndef ZCONF_H
 #define ZCONF_H
-#cmakedefine Z_PREFIX
-#cmakedefine Z_HAVE_UNISTD_H
 
 /*
  * If you *really* need a unique prefix for all types and library functions,
@@ -433,11 +431,11 @@ typedef uLong FAR uLongf;
    typedef unsigned long z_crc_t;
 #endif
 
-#ifdef HAVE_UNISTD_H    /* may be set to #if 1 by ./configure */
+@ZCONF_UNISTD_LINE@
 #  define Z_HAVE_UNISTD_H
 #endif
 
-#ifdef HAVE_STDARG_H    /* may be set to #if 1 by ./configure */
+@ZCONF_STDARG_LINE@
 #  define Z_HAVE_STDARG_H
 #endif
 

--- a/zlib.pc.cmakein
+++ b/zlib.pc.cmakein
@@ -1,12 +1,12 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@INSTALL_LIB_DIR@
-sharedlibdir=@INSTALL_LIB_DIR@
-includedir=@INSTALL_INC_DIR@
+exec_prefix=${prefix}
+libdir=@PC_INSTALL_LIB_DIR@
+sharedlibdir=${libdir}
+includedir=@PC_INSTALL_INC_DIR@
 
 Name: zlib
 Description: zlib compression library
-Version: @VERSION@
+Version: @ZLIB_FULL_VERSION@
 
 Requires:
 Libs: -L${libdir} -L${sharedlibdir} -lz


### PR DESCRIPTION
Fixes #497, at least on Linux, Mac, and FreeBSD.

Also: don't let Make build accidentally include a stale zconf.h.  (So also fixes #499.)

